### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "jsvat",
   "version": "2.0.0",
   "description": "Check the validity of the format of an EU VAT number",
-  "main": "./dist/jsvat.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.json",
     "test": "jest",


### PR DESCRIPTION
The package is currently broken because of the invalid `main` reference. Also, it's missing `types` configuration. This PR fixes it.