### PR TITLE
feat(jsvat): detect country before validation

### DIFF
--- a/lib/amd/lib/jsvat.js
+++ b/lib/amd/lib/jsvat.js
@@ -11,18 +11,32 @@ define(["require", "exports"], function (require, exports) {
                     short: country.codes[0],
                     long: country.codes[1],
                     numeric: country.codes[2]
-                }
+                },
+                formatValid: country.formatValid,
             }
         };
     }
     function removeExtraChars(vat = '') {
         return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
     }
+    function getCountryCode(country) {
+        if (country.name === 'Greece') {
+            return 'EL';
+        }
+        else {
+            return country.codes[0];
+        }
+    }
     function getCountry(vat, countriesList) {
         for (const country of countriesList) {
-            const regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);
-            if (regexpValidRes.isValid)
-                return country;
+            const countryCode = getCountryCode(country);
+            if (vat.startsWith(countryCode)) {
+                const formatValid = isVatValidToRegexp(vat, country.rules.regex);
+                return {
+                    ...country,
+                    formatValid: formatValid.isValid
+                };
+            }
         }
         return undefined;
     }
@@ -51,6 +65,8 @@ define(["require", "exports"], function (require, exports) {
         const country = getCountry(cleanVAT, countriesList);
         if (!country)
             return result;
+        if (!country.formatValid)
+            return makeResult(cleanVAT, country.formatValid, country);
         const isValid = isVatValid(cleanVAT, country);
         if (isValid)
             return makeResult(cleanVAT, isValid, country);

--- a/lib/commonjs/lib/jsvat.js
+++ b/lib/commonjs/lib/jsvat.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 function makeResult(vat, isValid, country) {
     return {
@@ -10,7 +21,8 @@ function makeResult(vat, isValid, country) {
                 short: country.codes[0],
                 long: country.codes[1],
                 numeric: country.codes[2]
-            }
+            },
+            formatValid: country.formatValid,
         }
     };
 }
@@ -18,12 +30,22 @@ function removeExtraChars(vat) {
     if (vat === void 0) { vat = ''; }
     return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
 }
+function getCountryCode(country) {
+    if (country.name === 'Greece') {
+        return 'EL';
+    }
+    else {
+        return country.codes[0];
+    }
+}
 function getCountry(vat, countriesList) {
     for (var _i = 0, countriesList_1 = countriesList; _i < countriesList_1.length; _i++) {
         var country = countriesList_1[_i];
-        var regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);
-        if (regexpValidRes.isValid)
-            return country;
+        var countryCode = getCountryCode(country);
+        if (vat.startsWith(countryCode)) {
+            var formatValid = isVatValidToRegexp(vat, country.rules.regex);
+            return __assign(__assign({}, country), { formatValid: formatValid.isValid });
+        }
     }
     return undefined;
 }
@@ -54,6 +76,8 @@ function checkVAT(vat, countriesList) {
     var country = getCountry(cleanVAT, countriesList);
     if (!country)
         return result;
+    if (!country.formatValid)
+        return makeResult(cleanVAT, country.formatValid, country);
     var isValid = isVatValid(cleanVAT, country);
     if (isValid)
         return makeResult(cleanVAT, isValid, country);

--- a/lib/es6/lib/jsvat.js
+++ b/lib/es6/lib/jsvat.js
@@ -8,18 +8,32 @@ function makeResult(vat, isValid, country) {
                 short: country.codes[0],
                 long: country.codes[1],
                 numeric: country.codes[2]
-            }
+            },
+            formatValid: country.formatValid,
         }
     };
 }
 function removeExtraChars(vat = '') {
     return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
 }
+function getCountryCode(country) {
+    if (country.name === 'Greece') {
+        return 'EL';
+    }
+    else {
+        return country.codes[0];
+    }
+}
 function getCountry(vat, countriesList) {
     for (const country of countriesList) {
-        const regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);
-        if (regexpValidRes.isValid)
-            return country;
+        const countryCode = getCountryCode(country);
+        if (vat.startsWith(countryCode)) {
+            const formatValid = isVatValidToRegexp(vat, country.rules.regex);
+            return {
+                ...country,
+                formatValid: formatValid.isValid
+            };
+        }
     }
     return undefined;
 }
@@ -48,6 +62,8 @@ export function checkVAT(vat, countriesList = []) {
     const country = getCountry(cleanVAT, countriesList);
     if (!country)
         return result;
+    if (!country.formatValid)
+        return makeResult(cleanVAT, country.formatValid, country);
     const isValid = isVatValid(cleanVAT, country);
     if (isValid)
         return makeResult(cleanVAT, isValid, country);

--- a/lib/system/lib/jsvat.js
+++ b/lib/system/lib/jsvat.js
@@ -11,18 +11,32 @@ System.register([], function (exports_1, context_1) {
                     short: country.codes[0],
                     long: country.codes[1],
                     numeric: country.codes[2]
-                }
+                },
+                formatValid: country.formatValid,
             }
         };
     }
     function removeExtraChars(vat = '') {
         return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
     }
+    function getCountryCode(country) {
+        if (country.name === 'Greece') {
+            return 'EL';
+        }
+        else {
+            return country.codes[0];
+        }
+    }
     function getCountry(vat, countriesList) {
         for (const country of countriesList) {
-            const regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);
-            if (regexpValidRes.isValid)
-                return country;
+            const countryCode = getCountryCode(country);
+            if (vat.startsWith(countryCode)) {
+                const formatValid = isVatValidToRegexp(vat, country.rules.regex);
+                return {
+                    ...country,
+                    formatValid: formatValid.isValid
+                };
+            }
         }
         return undefined;
     }
@@ -51,6 +65,8 @@ System.register([], function (exports_1, context_1) {
         const country = getCountry(cleanVAT, countriesList);
         if (!country)
             return result;
+        if (!country.formatValid)
+            return makeResult(cleanVAT, country.formatValid, country);
         const isValid = isVatValid(cleanVAT, country);
         if (isValid)
             return makeResult(cleanVAT, isValid, country);

--- a/lib/umd/lib/jsvat.js
+++ b/lib/umd/lib/jsvat.js
@@ -19,18 +19,32 @@
                     short: country.codes[0],
                     long: country.codes[1],
                     numeric: country.codes[2]
-                }
+                },
+                formatValid: country.formatValid,
             }
         };
     }
     function removeExtraChars(vat = '') {
         return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
     }
+    function getCountryCode(country) {
+        if (country.name === 'Greece') {
+            return 'EL';
+        }
+        else {
+            return country.codes[0];
+        }
+    }
     function getCountry(vat, countriesList) {
         for (const country of countriesList) {
-            const regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);
-            if (regexpValidRes.isValid)
-                return country;
+            const countryCode = getCountryCode(country);
+            if (vat.startsWith(countryCode)) {
+                const formatValid = isVatValidToRegexp(vat, country.rules.regex);
+                return {
+                    ...country,
+                    formatValid: formatValid.isValid
+                };
+            }
         }
         return undefined;
     }
@@ -59,6 +73,8 @@
         const country = getCountry(cleanVAT, countriesList);
         if (!country)
             return result;
+        if (!country.formatValid)
+            return makeResult(cleanVAT, country.formatValid, country);
         const isValid = isVatValid(cleanVAT, country);
         if (isValid)
             return makeResult(cleanVAT, isValid, country);

--- a/src/lib/jsvat.ts
+++ b/src/lib/jsvat.ts
@@ -46,6 +46,14 @@ function removeExtraChars(vat: string = ''): string {
   return vat.toString().toUpperCase().replace(/(\s|-|\.)+/g, '');
 }
 
+function getCountryCode(country: Country): string {
+  if (country.name === 'Greece') {
+    return 'EL';
+  } else {
+    return country.codes[0];
+  }
+}
+
 function getCountry(vat: string, countriesList: ReadonlyArray<Country>): Country | undefined {
   for (const country of countriesList) {
     const regexpValidRes = isVatValidToRegexp(vat, country.rules.regex);

--- a/types/lib/jsvat.d.ts
+++ b/types/lib/jsvat.d.ts
@@ -19,6 +19,9 @@ export interface Country {
     }) => boolean;
     rules: Rules;
 }
+export interface CountryWithFormatValid extends Country {
+    formatValid: boolean;
+}
 export interface VatCheckResult {
     value?: string;
     isValid: boolean;
@@ -29,6 +32,7 @@ export interface VatCheckResult {
             long: string;
             numeric: string;
         };
+        formatValid: boolean;
     };
 }
 export declare function checkVAT(vat: string, countriesList?: ReadonlyArray<Country>): VatCheckResult;


### PR DESCRIPTION
this pull request allows to detect the country even if the format is invalid based on the two first characters of the vat string. This also allows to differentiate between an unsupported country and an invalid country through the formatValid key on CountryWithFormatValid type

fixes #44 
fixes #65 