### PR TITLE
Add option to strict VAT ID validation check 

### DIFF
--- a/lib/es6/lib/jsvat.js
+++ b/lib/es6/lib/jsvat.js
@@ -62,11 +62,12 @@ function isVatValid(vat, country) {
         return false;
     return country.calcFn(regexResult[2]);
 }
-export function checkVAT(vat, countriesList = []) {
+export function checkVAT(vat, countriesList = [], shouldRemoveExtraChars = true) {
     if (!vat)
         return makeResult(vat, false);
     const cleanVAT = removeExtraChars(vat);
-    const country = getCountry(cleanVAT, countriesList);
-    const isValid = country ? isVatValid(cleanVAT, country) : false;
-    return makeResult(cleanVAT, isValid, country);
+    const vatId = shouldRemoveExtraChars ? cleanVAT : vat;
+    const country = getCountry(vatId, countriesList);
+    const isValid = country ? isVatValid(vatId, country) : false;
+    return makeResult(vatId, isValid, country);
 }

--- a/src/lib/jsvat.ts
+++ b/src/lib/jsvat.ts
@@ -105,7 +105,7 @@ function isVatValid(vat: string, country: Country): boolean {
 export function checkVAT(
   vat: string,
   countriesList: ReadonlyArray<Country> = [],
-  shouldCleanVat?: boolean
+  shouldCleanVat: boolean = true
 ): VatCheckResult {
   if (!vat) return makeResult(vat, false);
   const cleanVAT = removeExtraChars(vat);

--- a/src/lib/jsvat.ts
+++ b/src/lib/jsvat.ts
@@ -102,10 +102,14 @@ function isVatValid(vat: string, country: Country): boolean {
   return country.calcFn(regexResult[2]);
 }
 
-export function checkVAT(vat: string, countriesList: ReadonlyArray<Country> = []): VatCheckResult {
+export function checkVAT(
+  vat: string,
+  countriesList: ReadonlyArray<Country> = [],
+  shouldCleanVat?: boolean
+): VatCheckResult {
   if (!vat) return makeResult(vat, false);
   const cleanVAT = removeExtraChars(vat);
-  const country = getCountry(cleanVAT, countriesList);
-  const isValid = country ? isVatValid(cleanVAT, country) : false;
-  return makeResult(cleanVAT, isValid, country);
+  const country = getCountry(shouldCleanVat ? cleanVAT : vat, countriesList);
+  const isValid = country ? isVatValid(shouldCleanVat ? cleanVAT : vat, country) : false;
+  return makeResult(shouldCleanVat ? cleanVAT : vat, isValid, country);
 }

--- a/src/lib/jsvat.ts
+++ b/src/lib/jsvat.ts
@@ -105,11 +105,12 @@ function isVatValid(vat: string, country: Country): boolean {
 export function checkVAT(
   vat: string,
   countriesList: ReadonlyArray<Country> = [],
-  shouldCleanVat: boolean = true
+  shouldRemoveExtraChars: boolean = true
 ): VatCheckResult {
   if (!vat) return makeResult(vat, false);
   const cleanVAT = removeExtraChars(vat);
-  const country = getCountry(shouldCleanVat ? cleanVAT : vat, countriesList);
-  const isValid = country ? isVatValid(shouldCleanVat ? cleanVAT : vat, country) : false;
-  return makeResult(shouldCleanVat ? cleanVAT : vat, isValid, country);
+  const vatId = shouldRemoveExtraChars ? cleanVAT : vat;
+  const country = getCountry(vatId, countriesList);
+  const isValid = country ? isVatValid(vatId, country) : false;
+  return makeResult(vatId, isValid, country);
 }

--- a/test/germany.spec.js
+++ b/test/germany.spec.js
@@ -1,4 +1,4 @@
-import { checkVAT, germany } from '../index';
+import { germany } from '../index';
 import { codes, invalid, name, valid, validOnlyByFormat } from './countries_vat_lists/germany.vat';
 import {
   addCharsToString,

--- a/test/germany.spec.js
+++ b/test/germany.spec.js
@@ -1,6 +1,12 @@
-import { germany } from '../index';
+import { checkVAT, germany } from '../index';
 import { codes, invalid, name, valid, validOnlyByFormat } from './countries_vat_lists/germany.vat';
-import { addCharsToString, checkInvalidVat, checkOnlyValidFormatVat, checkValidVat } from './utils';
+import {
+  addCharsToString,
+  checkInvalidVat,
+  checkOnlyValidFormatVat,
+  checkValidVat,
+  checkValidVatWithoutRemovingExtraChars
+} from './utils';
 
 describe('Germany', () => {
   it('should return "true" result for valid VATs', () => {
@@ -15,8 +21,20 @@ describe('Germany', () => {
     valid.map((vat) => addCharsToString(vat, '-')).forEach((vat) => checkValidVat(vat, [germany], codes, name));
   });
 
+  it('should return "false" result for valid VATs with extra dash characters when shouldRemoveExtraChars is set to false', () => {
+    valid
+      .map((vat) => addCharsToString(vat, '-'))
+      .forEach((vat) => checkValidVatWithoutRemovingExtraChars(vat, [germany], codes, name));
+  });
+
   it('should return "true" result for valid VATs with extra space characters', () => {
     valid.map((vat) => addCharsToString(vat, ' ')).forEach((vat) => checkValidVat(vat, [germany], codes, name));
+  });
+
+  it('should return "false" result for valid VATs with extra space characters when shouldRemoveExtraChars is set to false', () => {
+    valid
+      .map((vat) => addCharsToString(vat, '  '))
+      .forEach((vat) => checkValidVatWithoutRemovingExtraChars(vat, [germany], codes, name));
   });
 
   it('should return "false" result for invalid VATs', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -14,6 +14,13 @@ export function checkValidVat(vat, countriesList, codes, name) {
   expect(result.country.isoCode.numeric).toBe(codes[2]);
 }
 
+export function checkValidVatWithoutRemovingExtraChars(vat, countriesList, codes, name) {
+  const result = checkVAT(vat, countriesList, false);
+
+  if (result.isValid) console.info('Following VAT should be invalid:', vat);
+  expect(result.isValid).toBe(false);
+}
+
 export function checkInvalidVat(vat, countriesList) {
   const result = checkVAT(vat, countriesList);
   if (result.isValid) console.info('Following VAT should be invalid:', vat);


### PR DESCRIPTION
add option to do strict VAT validation check:
- allow the user to choose between clean & dirty when checking the vatId
- set `shouldRemoveExtraChars` default value to true in order to avoid breaking changes

fixes issue Nr. [123](https://github.com/se-panfilov/jsvat/issues/123)
